### PR TITLE
Remove `batch-id` in favour of `campaign id`

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,55 @@
+# Notes
+
+- A 'collection request' is started with the `:kixi.collect/request-collection` command.
+- It is then confirmed or rejected with events: `:kixi.collect/collection-requested` or `:kixi.collect/collection-request-rejected` respectively.
+- Upon success - handling of the event - there are two aggregates and a process manager that spring to life:
+
+## Aggregates
+
+### REQUESTS
+A single collection request event actually creates many 'REQUEST' (CR) entities; *one per group specified in the event*. CRs can be used for individual response tracking and schema reporting.
+
+### CAMPAIGNS
+A single 'CAMPAIGN' (CC) encompasses all of the CRs in a collection request event. It also retains information about the original event, such as `sender` and `message`.
+
+`One CAMPAIGN has many COLLECTION REQUESTS`.
+
+## Process Manager
+The "process manager for collection requests" (PMCR) is responsible for coordinating the change of datastore permissions and the sending of emails to the relevant groups, informing them they can now add to a particular bundle.
+
+The process manager runs on an FSM which plugs into the `kixi.comms` concept of chaining commands and events. The FSM is determined by the events that cause the state to progress - read more about this at https://github.com/ztellman/automat.
+
+``` clojure
+(def state-machine
+  [[{:kixi.event/type :kixi.collect/collection-requested}            (a/$ :update-sharing-permission)]
+   (a/or [{:kixi.event/type :kixi.datastore/sharing-changed}         (a/$ :send-group-email)]
+         [{:kixi.event/type :kixi.datastore/sharing-change-rejected} (a/$ :fail)])
+   (a/or [{:kixi.event/type :kixi.mailer/group-mail-accepted}        (a/$ :complete)]
+         [{:kixi.event/type :kixi.mailer/group-mail-rejected}        (a/$ :fail)])])
+```
+
+Once the state has successfully advanced, the current node releases a command.
+
+To recap, events are fed in and commands are received out. `kixi.comms` facilitates this chain.
+
+- A 'collection request process' is started by the receipt of the `:kixi.collect/collection-requested` event.
+- For each CR, an individual 'process manager state' (PMCR) is created which represents the journey of that particular CR. E.g. if there are three CRs, there will be three PMCRs created.
+- PMCRs created by a single `:kixi.collect/collection-requested` event are linked via their parent CAMPAIGN - sometimes referred to as "their batch".
+- When an individual PMCR is *advanced* **an entirely new PMCR is created**. It doesn't replace the existing PMCR; now two exist which both refer to the same CR.
+- Detecting whether a 'batch' has completed (all the CRs in a CAMPAIGN has finished the process/FSM) becomes an exercise of checking each PMCR in a batch and seeing whether particular 'end states' (usually `:complete` or `:fail`) have been reached for a particular CR.
+
+Example process manager batch table:
+
+| CC | CR | PMCR | PMCR value                 |
+|----|----|------|----------------------------|
+| 1  | A  |  Z   | :update-sharing-permission |
+| 1  | A  |  Y   | :send-group-email          |
+| 1  | A  |  X   | :complete                  |
+| 1  | B  |  W   | :update-sharing-permission |
+| 1  | B  |  V   | :send-group-email          |
+| 1  | B  |  U   | :complete                  |
+| 1  | C  |  T   | :update-sharing-permission |
+| 1  | C  |  S   | :fail                      |
+| 2  | D  |  R   | :update-sharing-permission |
+| 2  | D  |  Q   | :send-group-email          |
+| 2  | D  |  P   | :complete                  |

--- a/src/kixi/collect/definitions.clj
+++ b/src/kixi/collect/definitions.clj
@@ -40,7 +40,7 @@
 (defmethod comms/command-payload
   [:kixi.collect.process-manager.collection-request/complete-process "1.0.0"]
   [_]
-  (s/keys :req [::pmcr/batch-id]))
+  (s/keys :req [::cc/id]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -68,7 +68,7 @@
 (defmethod comms/event-payload
   [:kixi.collect.process-manager.collection-request/process-completed "1.0.0"]
   [_]
-  (s/keys :req [::pmcr/batch-id
+  (s/keys :req [::cc/id
                 ::pmcr/results
                 ::cr/message
                 ::cr/sender
@@ -77,7 +77,7 @@
 (defmethod comms/event-payload
   [:kixi.collect.process-manager.collection-request/complete-process-rejected "1.0.0"]
   [_]
-  (s/keys :req [::pmcr/batch-id]))
+  (s/keys :req [::cc/id]))
 
 
 

--- a/src/kixi/collect/process_manager.clj
+++ b/src/kixi/collect/process_manager.clj
@@ -5,4 +5,4 @@
   (save-state! [this old-state new-state event new-id]))
 
 (defprotocol IProcessManagerCollectionRequestBackend
-  (get-batch [this batch-id]))
+  (get-batch [this campaign-id]))

--- a/src/kixi/collect/process_manager/collection_request/dynamodb.clj
+++ b/src/kixi/collect/process_manager/collection_request/dynamodb.clj
@@ -11,6 +11,7 @@
             [taoensso.timbre :as log]))
 
 (ks/alias 'cr 'kixi.collect.request)
+(ks/alias 'cc 'kixi.collect.campaign)
 
 (defn primary-collection-request-process-manager-table-name
   [profile]
@@ -31,9 +32,9 @@
     [communications profile endpoint directory
      client]
   pm/IProcessManagerCollectionRequestBackend
-  (get-batch [this batch-id]
+  (get-batch [this campaign-id]
     (db/query client (batches-collection-request-process-manager-table-name profile)
-              {::pmcr/batch-id batch-id}
+              {::cc/id campaign-id}
               nil))
   component/Lifecycle
   (start [component]
@@ -74,13 +75,13 @@
     ;; write new
     (let [table (primary-collection-request-process-manager-table-name profile)
           batches-table (batches-collection-request-process-manager-table-name profile)]
-      (let [batch-id (get-in new-state [:value ::pmcr/batch-id])
+      (let [cid (get-in new-state [:value ::cc/id])
             t (ct/timestamp)
             new-item (assoc new-state
                             ::pmcr/id new-id
                             ::pmcr/created-at t)]
         (db/put-item client table new-item)
-        (db/put-item client batches-table {::pmcr/batch-id batch-id
+        (db/put-item client batches-table {::cc/id cid
                                            ::pmcr/id new-id
                                            ::pmcr/created-at t
                                            ::cr/ids (get-in new-state [:value ::cr/ids])

--- a/src/kixi/collect/process_manager/collection_request/spec.clj
+++ b/src/kixi/collect/process_manager/collection_request/spec.clj
@@ -5,10 +5,10 @@
             [kixi.spec :as ks]))
 
 (ks/alias 'cr 'kixi.collect.request)
+(ks/alias 'cc 'kixi.collect.campaign)
 (ks/alias 'pmcr 'kixi.collect.process-manager.collection-request)
 
 (s/def ::pmcr/id sc/uuid?)
-(s/def ::pmcr/batch-id sc/uuid?)
 (s/def ::pmcr/created-at sc/timestamp?)
 (s/def ::pmcr/action (s/with-gen keyword?
                        #(gen/fmap keyword (gen/string-alphanumeric))))
@@ -17,8 +17,8 @@
 
 (s/def ::pmcr/batch
   (s/keys :req [::pmcr/id
+                ::cc/id
                 ::cr/id
                 ::cr/ids
                 ::pmcr/action
-                ::pmcr/created-at
-                ::pmcr/batch-id]))
+                ::pmcr/created-at]))

--- a/src/kixi/collect/process_manager/migrators/dynamodb/migrator_20180212_init.clj
+++ b/src/kixi/collect/process_manager/migrators/dynamodb/migrator_20180212_init.clj
@@ -9,6 +9,7 @@
             [taoensso.timbre :as log]))
 
 (ks/alias 'pmcr 'kixi.collect.process-manager.collection-request)
+(ks/alias 'cc 'kixi.collect.campaign)
 
 (def primary-write-provision 10)
 (def primary-read-provision 10)
@@ -36,7 +37,7 @@
                        :block? true})
     (far/create-table conn
                       (crdb/batches-collection-request-process-manager-table-name profile)
-                      [(db/dynamo-col ::pmcr/batch-id) :s]
+                      [(db/dynamo-col ::cc/id) :s]
                       {:range-keydef [(db/dynamo-col ::pmcr/id) :s]
                        :throughput {:read batches-read-provision
                                     :write batches-write-provision}

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -562,7 +562,7 @@
   ([uid message groups]
    (send-collection-request uid uid message groups))
   ([uid uid2 message groups]
-   (println "Creating datapack...")
+   (println "Creating datapack for" uid)
    (let [dr (empty-datapack uid)]
      (when-success dr
        (println "Datapack created")

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -191,8 +191,10 @@
       (mapv (fn [c]
               (async/go-loop
                   [event (async/<! c)]
-                (println "...observing event " (or (:kixi.comms.event/key event)
-                                                   (:kixi.event/type event)) uid)
+                (when event
+                  (println "...observing event " (or (:kixi.comms.event/key event)
+                                                     (:kixi.event/type event)
+                                                     event) uid))
                 (if (and (event-for uid event)
                          (or (event-types (:kixi.comms.event/key event))
                              (event-types (:kixi.event/type event))))

--- a/test/kixi/integration/process_manager/collection_request_test.clj
+++ b/test/kixi/integration/process_manager/collection_request_test.clj
@@ -13,7 +13,7 @@
 
 (def pmcr (atom nil))
 
-(use-fixtures :once
+(use-fixtures :each
   (cycle-system-fixture {:spec {:kixi.event/type #{:kixi.collect/collection-requested}}})
   (extract-component :process-manager-collection-request pmcr)
   extract-comms)


### PR DESCRIPTION
**Remove `batch-id` in favour of `campaign id`**
Does the same job, without the need for an extra UUID. Enables
aggregates to see when campaigns are done.