### PR TITLE
Add cleanup routines so that process manager rows are removed

### DIFF
--- a/src/kixi/collect/process_manager.clj
+++ b/src/kixi/collect/process_manager.clj
@@ -2,7 +2,8 @@
 
 (defprotocol IProcessManagerBackend
   (get-state [this event])
-  (save-state! [this old-state new-state event new-id]))
+  (save-state! [this old-state new-state event new-id])
+  (clean-up! [this event]))
 
 (defprotocol IProcessManagerCollectionRequestBackend
   (get-batch [this campaign-id]))

--- a/src/kixi/collect/process_manager/collection_request/dynamodb.clj
+++ b/src/kixi/collect/process_manager/collection_request/dynamodb.clj
@@ -86,4 +86,13 @@
                                            ::pmcr/created-at t
                                            ::cr/ids (get-in new-state [:value ::cr/ids])
                                            ::cr/id (get-in new-state [:value ::cr/id])
-                                           ::pmcr/action (get-in new-state [:value ::pmcr/action])})))))
+                                           ::pmcr/action (get-in new-state [:value ::pmcr/action])}))))
+  (clean-up! [this event]
+    (let [table (primary-collection-request-process-manager-table-name profile)
+          batches-table (batches-collection-request-process-manager-table-name profile)
+          cc-id (-> event ::cc/id)
+          batch-results (pm/get-batch this cc-id)]
+      (run! (fn [r]
+              (db/delete-item client table (select-keys r [::pmcr/id]))
+              (db/delete-item client batches-table (select-keys r [::pmcr/id ::cc/id])))
+            batch-results))))

--- a/src/kixi/collect/request/aggregate/dynamodb.clj
+++ b/src/kixi/collect/request/aggregate/dynamodb.clj
@@ -77,6 +77,5 @@
     component)
   agrr/ICollectionRequestAggregate
   (get-by-id [this id]
-    (update
-     (db/get-item {:endpoint endpoint} (primary-collection-request-table profile) ::cr/id id)
-     ::cr/response-ids set)))
+    (when-let [r (db/get-item {:endpoint endpoint} (primary-collection-request-table profile) ::cr/id id)]
+      (update r ::cr/response-ids set))))

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -183,6 +183,21 @@
                         :kixi.datastore.metadatastore/provenance
                         :kixi.user/id]))))
 
+(defn wait-for-pred
+  ([p]
+   (wait-for-pred p wait-tries))
+  ([p tries]
+   (wait-for-pred p tries wait-per-try))
+  ([p tries ms]
+   (loop [try tries]
+     (when (and (pos? try))
+       (let [result (p)]
+         (if (not result)
+           (do
+             (Thread/sleep ms)
+             (recur (dec try)))
+           result))))))
+
 (defn wait-for-events
   [uid & event-types]
   (let [event-types (set event-types)]

--- a/test/kixi/integration/request/aggregate_test.clj
+++ b/test/kixi/integration/request/aggregate_test.clj
@@ -12,7 +12,7 @@
 
 (def collection-request-aggregate (atom nil))
 
-(use-fixtures :once
+(use-fixtures :each
   (cycle-system-fixture {:spec {:kixi.event/type #{:kixi.collect/collection-requested}}})
   (extract-component :collect-request-aggregate collection-request-aggregate)
   extract-comms)
@@ -25,6 +25,6 @@
       ;; check the collection-requests made it into the aggregate
       (is (= :kixi.collect/collection-requested (:kixi.event/type event)))
       (doseq [cr-id (vals (::cr/group-collection-requests event))]
-        (let [cr (agr/get-by-id @collection-request-aggregate cr-id)]
+        (let [cr (wait-for-pred #(agr/get-by-id @collection-request-aggregate cr-id))]
           (is (s/valid? ::cr/db-item cr)
               (with-out-str (s/explain ::cr/db-item cr))))))))


### PR DESCRIPTION
We have no reason to keep process manager state around once the process has completed, so right now we hose the rows. Any _aggregates_ that care about the result should receive the event and so something appropriate.