### PR TITLE
Make `requested-groups` and `receiving-groups` separate

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                  [kixi/kixi.metrics "0.4.1" :upgrade :kixi]
                  [kixi/joplin.core "0.3.10-SNAPSHOT" :upgrade :kixi]
                  [kixi/joplin.dynamodb "0.3.10-SNAPSHOT" :upgrade :kixi]
-                 [kixi/kixi.spec "0.1.25" :upgrade :kixi]
+                 [kixi/kixi.spec "0.1.26" :upgrade :kixi]
                  [medley "1.0.0"]
                  [org.clojure/clojure "1.9.0"]
                  [spootnik/signal "0.2.1"]

--- a/src/kixi/collect/request/aggregate.clj
+++ b/src/kixi/collect/request/aggregate.clj
@@ -48,13 +48,14 @@
     {:partition-key (or id (uuid))}]))
 
 (defn create-request
-  [{:keys [kixi/user ::cr/groups ::cr/message ::ms/id]}]
+  [{:keys [kixi/user ::cr/requested-groups ::cr/message ::ms/id ::cr/receiving-groups]}]
   [{::event/type :kixi.collect/collection-requested
     ::event/version "1.0.0"
     ::ms/id id
     ::cc/id (uuid)
     ::cr/message message
-    ::cr/group-collection-requests (zipmap groups (repeatedly uuid))
+    ::cr/group-collection-requests (zipmap requested-groups (repeatedly uuid))
+    ::cr/receiving-groups receiving-groups
     ::cr/sender user}
    {:partition-key id}])
 
@@ -94,7 +95,7 @@
 
 (defn create-request-collection-handler-inner
   [directory bundle cmd]
-  (let [{:keys [kixi/user ::cr/groups ::cr/message ::ms/id]} cmd]
+  (let [{:keys [kixi/user ::ms/id]} cmd]
     (cond
       (not bundle)
       (reject-request :unauthorised id)

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -567,7 +567,8 @@
     {::cmd/type :kixi.collect/request-collection
      ::cmd/version "1.0.0"
      ::cr/message message
-     ::cr/groups groups
+     ::cr/requested-groups groups
+     ::cr/receiving-groups (vec-if-not ugroup)
      ::ms/id bid
      :kixi/user {:kixi.user/id uid
                  :kixi.user/groups (vec-if-not ugroup)}}


### PR DESCRIPTION
**Make `requested-groups` and `receiving-groups` separate**
Fundamentally, the requested event needs to show which groups to assign vision to